### PR TITLE
Remove an unused setting in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,6 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 title: "PyCon UK 2020"
-email: devnull@example.com
 description: >-
   PyCon UK will be returning to Cardiff City Hall from Saturday 10th to Wednesday 14th October 2020.
   More details coming soon!

--- a/src/_headers
+++ b/src/_headers
@@ -1,6 +1,0 @@
-# Set some custom Netlify headers; see
-# https://docs.netlify.com/routing/headers/#syntax-for-the-headers-file
-
-# Cache all the fonts forever, so they don't "pop" in on every page load.
-/theme/fonts/*
-    Cache-Control: "public, max-age=31536000" always;


### PR DESCRIPTION
This is actually to trick the Netlify build into running where I can see it – I think I might have busted something with header rules last night.